### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/SproutActive.php
+++ b/src/SproutActive.php
@@ -22,6 +22,6 @@ class SproutActive extends Plugin
 
         self::$app = $this->get('app');
 
-        Craft::$app->view->twig->addExtension(new TwigExtensions());
+        Craft::$app->view->registerTwigExtension(new TwigExtensions());
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.